### PR TITLE
Nuke byte-streams dependency

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,9 +9,9 @@ jobs:
     strategy:
       matrix:
         jdk:
-          - 8
           - 11
           - 17
+          - 19
         clojure:
           - 1.9.0
           - 1.10.0
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/setup-java@v2
         with:
           java-version: "${{ matrix.jdk }}"
-          distribution: zulu
+          distribution: temurin
           cache: maven
       - uses: delaguardo/setup-clojure@3.5
         with:

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ A library to handle ActivityPub-related crypto needs.
 [social.kitsune/csele "0.6.1"]
 ```
 
+Can't use InputStreams as inputs on Java 8.
+
 ## License
 
 Copyright © 2018 @[valerauko](https://github.com/valerauko)

--- a/project.clj
+++ b/project.clj
@@ -5,8 +5,7 @@
             :url "http://www.eclipse.org/legal/epl-v20.html"}
   :dependencies [[commons-codec/commons-codec "1.15"]
                  [org.bouncycastle/bcprov-jdk15on "1.70"]
-                 [org.bouncycastle/bcpkix-jdk15on "1.70"]
-                 [org.clj-commons/byte-streams "0.3.1"]]
+                 [org.bouncycastle/bcpkix-jdk15on "1.70"]]
   :deploy-repositories {"clojars" {:url "https://repo.clojars.org/"
                                    :username :env/clojars_user
                                    :password :env/clojars_token}}

--- a/src/csele/conversions.clj
+++ b/src/csele/conversions.clj
@@ -1,0 +1,16 @@
+(ns csele.conversions
+  (:import [java.io
+            InputStream]))
+
+(defprotocol Byteish
+  (->bytes ^bytes [_]))
+
+(extend-protocol Byteish
+  (Class/forName "[B")
+  (->bytes [input] input)
+
+  String
+  (->bytes [input] (.getBytes input))
+
+  InputStream
+  (->bytes [input] (.readAllBytes input)))

--- a/src/csele/conversions.clj
+++ b/src/csele/conversions.clj
@@ -13,4 +13,6 @@
   (->bytes [input] (.getBytes input))
 
   InputStream
-  (->bytes [input] (.readAllBytes input)))
+  (->bytes [input]
+    (.reset input)
+    (.readAllBytes input)))

--- a/src/csele/hash.clj
+++ b/src/csele/hash.clj
@@ -1,5 +1,5 @@
 (ns csele.hash
-  (:require [clj-commons.byte-streams :as bs])
+  (:require [csele.conversions :refer [->bytes]])
   (:import [java.io InputStream]
            [java.util Base64]
            [java.security MessageDigest]
@@ -9,8 +9,8 @@
 (defn hash-hex
   "SHA3 hash of string"
   ([input] (hash-hex input 512))
-  ([^String input ^Integer strength]
-   (let [bytes (.getBytes input)
+  ([input ^Integer strength]
+   (let [bytes (->bytes input)
          sha3 (SHA3$DigestSHA3. strength)]
      (.update sha3 bytes)
      (Hex/encodeHexString (.digest sha3)))))
@@ -19,7 +19,7 @@
   "Base64 encoded SHA-256 hash of input."
   [input]
   (if (instance? InputStream input) (.reset ^InputStream input))
-  (let [bytes (bs/to-byte-array input)
+  (let [bytes (->bytes input)
         bowel (MessageDigest/getInstance "SHA-256")
         encoder (Base64/getEncoder)]
     (->> bytes

--- a/src/csele/hash.clj
+++ b/src/csele/hash.clj
@@ -18,7 +18,6 @@
 (defn hash-base64
   "Base64 encoded SHA-256 hash of input."
   [input]
-  (if (instance? InputStream input) (.reset ^InputStream input))
   (let [bytes (->bytes input)
         bowel (MessageDigest/getInstance "SHA-256")
         encoder (Base64/getEncoder)]

--- a/src/csele/signatures.clj
+++ b/src/csele/signatures.clj
@@ -1,6 +1,6 @@
 (ns csele.signatures
-  (:require [csele.keys :as keys]
-            [clj-commons.byte-streams :as bs])
+  (:require [csele.conversions :refer [->bytes]]
+            [csele.keys :as keys])
   (:import [java.security Security Signature]
            [java.io ByteArrayInputStream]
            [java.util Base64]
@@ -17,7 +17,7 @@
   (let [sig (doto (Signature/getInstance algo)
                   (.initVerify ^JCERSAPublicKey
                     (keys/string-to-key public-key))
-                  (.update (bs/to-byte-array actual-data)))]
+                  (.update (->bytes actual-data)))]
     (.verify sig
       (.decode (Base64/getDecoder) signature))))
 
@@ -26,6 +26,6 @@
   [data private-key]
   (let [sig (doto (Signature/getInstance algo)
                   (.initSign (keys/string-to-key private-key))
-                  (.update (bs/to-byte-array data)))]
+                  (.update (->bytes data)))]
     (.encodeToString (Base64/getEncoder)
       (.sign sig))))

--- a/test/csele/conversions_test.clj
+++ b/test/csele/conversions_test.clj
@@ -1,0 +1,23 @@
+(ns csele.conversions-test
+  (:require [clojure.test :refer :all]
+            [csele.conversions :refer [->bytes]])
+  (:import [java.io
+            ByteArrayInputStream]
+           [java.util
+            Arrays]))
+
+(deftest bytes-test
+  (testing "'Converting' bytes"
+    (let [byte-arr (.getBytes "foo")]
+      (is (= (->bytes byte-arr) byte-arr))))
+  (testing "Converting a string"
+    (let [string "Lorem ipsum"]
+      (is (Arrays/equals (->bytes string) (.getBytes string)))))
+  (testing "Converting a stream"
+    (let [stream (-> "foo" .getBytes ByteArrayInputStream.)]
+      (is (Arrays/equals (->bytes stream) (.getBytes "foo")))
+      (is (Arrays/equals (->bytes stream) (.getBytes "foo"))
+          "Can be called repeatedly (on a resetable stream)")))
+  (testing "Converting null"
+    (is (thrown? IllegalArgumentException (->bytes nil))
+        "Not supported")))

--- a/test/csele/hash_test.clj
+++ b/test/csele/hash_test.clj
@@ -12,7 +12,8 @@
     (is (= (hash-hex "foo" 384) fix/foo-sha3-384))))
 
 (deftest base64-test
-  (let [consumed-input (-> "foo" .getBytes ByteArrayInputStream. ->bytes)]
+  (let [consumed-input (doto (-> "foo" .getBytes ByteArrayInputStream.)
+                             (.readAllBytes))] ;; "consume" the stream, throw away
     (testing "Produces correct base64 hash of input"
       (is (= (hash-base64 "foo") fix/foo-base64)))
     (testing "Works with consumed streams too"

--- a/test/csele/hash_test.clj
+++ b/test/csele/hash_test.clj
@@ -1,6 +1,6 @@
 (ns csele.hash-test
   (:require [clojure.test :refer :all]
-            [clj-commons.byte-streams :as bs]
+            [csele.conversions :refer [->bytes]]
             [csele.fixtures.hash :as fix]
             [csele.hash :refer :all])
   (:import [java.io ByteArrayInputStream]))
@@ -12,8 +12,7 @@
     (is (= (hash-hex "foo" 384) fix/foo-sha3-384))))
 
 (deftest base64-test
-  (let [consumed-input (doto (-> "foo" .getBytes ByteArrayInputStream.)
-                             (bs/to-byte-array))]
+  (let [consumed-input (-> "foo" .getBytes ByteArrayInputStream. ->bytes)]
     (testing "Produces correct base64 hash of input"
       (is (= (hash-base64 "foo") fix/foo-base64)))
     (testing "Works with consumed streams too"


### PR DESCRIPTION
Considering Csele works with a pretty obvious set of inputs, having a dependency that pulls in its own Executor is a bit of an overkill.